### PR TITLE
Report on missing files

### DIFF
--- a/tasker/task.py
+++ b/tasker/task.py
@@ -293,7 +293,6 @@ class TaskUnit(object):
             try:
                 input_mtimes.append(inf.mtime)
             except OSError:
-                print inf
                 missing_files.append(inf)
         output_mtime = self._output_mtime()
 

--- a/tasker/task.py
+++ b/tasker/task.py
@@ -15,6 +15,7 @@
 import exceptions, os, sys
 import inspect, contextlib, functools
 from collections import OrderedDict
+from warnings import warn
 import json
 
 from path import path
@@ -262,6 +263,11 @@ class TaskUnit(object):
 
         run : if true, run() tasks that are out of date.
         force : if true, run *this* task whether it is out of date or not.
+
+        Notes on returned dictionary keys:
+            all_current : not (Does/will this task need to be run()?)
+            done : Can the output be produced trivially?
+                (For tasks that don't store their output, are all deps up to date?)
         """
         if self._syncing:
             raise RuntimeError('Cyclic dependency: "%s" somehow depends on '
@@ -282,32 +288,43 @@ class TaskUnit(object):
             )
 
         input_mtimes = [-1] + [ur['mtime'] for ur in up_results]
+        missing_files = []
         for inf in self.input_files:
             try:
                 input_mtimes.append(inf.mtime)
             except OSError:
-                pass
+                print inf
+                missing_files.append(inf)
         output_mtime = self._output_mtime()
 
-        # Run task if missing outputs, stale outputs,
-        # or an upstream task has been re-run.
+        # Run task if missing outputs, stale outputs, or an upstream task has been re-run.
         if force or output_mtime == -1 or \
                     (output_mtime is not None and output_mtime < max(input_mtimes)) or \
                     not result['all_current']:
             result['all_current'] = False
             result['needed_tasks'].append(self)
+            result['done'] = False
             if run:
+                for missing_file in missing_files:
+                    warn('Attempting to run task "%s", but required file "%s" is '
+                         'missing. Failure is likely.' % (self.__name__, missing_file))
                 self.run()
                 output_mtime = self._output_mtime()
                 if output_mtime is not None and output_mtime < max(input_mtimes):
                     raise RuntimeError('Task "%s" failed to update its output files.'
                                        % self.__name__)
+        elif output_mtime is None and missing_files:
+            # Edge case: if this task does not store its outputs, and some input files
+            # are missing, then asking for its output would fail.
+            result['done'] = False
+        else:
+            result['done'] = True
 
         if output_mtime is None:
             result['mtime'] = max(input_mtimes)  # No outputs
         else:
             result['mtime'] = output_mtime
-        return result  # needed_tasks, all_current, mtime
+        return result  # needed_tasks, visited_tasks, missing_files, all_current, mtime
 
     # Public interface
     def __call__(self):
@@ -373,8 +390,16 @@ class TaskUnit(object):
         self._walk_up(run=True)
 
     def is_current(self):
-        """True if this task and all its dependencies are current."""
-        return self._walk_up()['all_current']
+        """True if this task's output is readily available.
+
+        If the task does store its output, this implies that the output
+        has been computed and stored, and that no dependency is newer.
+        (Missing upstream files do *not* make this False.)
+
+        If the task does not store its output, this implies that all
+        its dependencies are available and current.
+        """
+        return self._walk_up()['done']
 
     def report(self):
         """List tasks that would have to be run to update outputs."""

--- a/tasker/tests/test_task.py
+++ b/tasker/tests/test_task.py
@@ -102,12 +102,12 @@ class TestTask(unittest.TestCase):
                             set([self.task.one, self.task.two,
                                  self.task.three, self.task.four]))
     def test_clearall(self):
-        self.task.four()
-        self.assertSetEqual(set(self.task.four.report()), set())
+        self.task.three()
+        self.assertSetEqual(set(self.task.three.report()), set())
         self.task.clear()
-        self.assertSetEqual(set(self.task.four.report()),
+        self.assertSetEqual(set(self.task.three.report()),
                             set([self.task.one, self.task.two,
-                                 self.task.three, self.task.four]))
+                                 self.task.three]))
     def test_twodirs(self):
         """Make sure separate task instances do not mix paths"""
         td2 = path(tempfile.mkdtemp())
@@ -308,6 +308,18 @@ class TestNewStyleTasks(TestTask):
         def a_list(tsk):
             return [1, 2, 3]
         a_list()
+
+    def test_missing_file(self):
+        """Check that missing dependencies make a task incomplete."""
+        assert not self.task.four.is_current()  # Direct file dependency
+
+        # Indirect file dependency
+        missing_file = storage.JSON('dummy_missing')
+        @self.task
+        def missing_dependency(tsk, missing_file=missing_file):
+            return None
+        assert not self.task.missing_dependency.is_current()  # Direct file dependency
+
 
     def test_traceback(self):
         """Cursory check of traceback editing"""


### PR DESCRIPTION
The main user-facing consequence of this change is that tasks that do not store their output, and that cannot compute their output because of one or more missing files, will not show up as "Done" in the output of `menu()`.
